### PR TITLE
Fixed test case to use asserts

### DIFF
--- a/newrelic-kafka-connector/src/main/java/com/newrelic/telemetry/metrics/TelemetryMetricsSinkTask.java
+++ b/newrelic-kafka-connector/src/main/java/com/newrelic/telemetry/metrics/TelemetryMetricsSinkTask.java
@@ -140,7 +140,7 @@ public class TelemetryMetricsSinkTask extends SinkTask {
                                                 summaryModel.timestamp,
                                                 summaryModel.timestamp + summaryModel.interval,
                                                 buildAttributes(summaryModel.attributes));
-                                log.info("this is count " + summary.toString());
+                                log.info("this is summary " + summary.toString());
                                 metricBuffer.addMetric(summary);
                                 break;
                         }

--- a/newrelic-kafka-connector/src/test/java/com/newrelic/telemetry/TelemetrySinkConnectorConfigTest.java
+++ b/newrelic-kafka-connector/src/test/java/com/newrelic/telemetry/TelemetrySinkConnectorConfigTest.java
@@ -1,11 +1,15 @@
 package com.newrelic.telemetry;
 
 import org.junit.Test;
+import static org.junit.Assert.*;
 
 public class TelemetrySinkConnectorConfigTest {
 
     @Test
     public void doc() {
-        System.out.println(TelemetrySinkConnectorConfig.conf().toRst());
+        String stringConf = TelemetrySinkConnectorConfig.conf().toRst();
+        assertTrue(stringConf.contains("api.key"));
+        assertTrue(stringConf.contains("max.retries"));
+        assertTrue(stringConf.contains("retry.interval.ms"));
     }
 }


### PR DESCRIPTION
- improved `TelemetrySinkConnectorConfigTest` test case to assert for expected information.
- Fixed a log entry that looked like it had a copy/paste error.