### PR TITLE
Rahul retry log levels

### DIFF
--- a/newrelic-kafka-connector/README.md
+++ b/newrelic-kafka-connector/README.md
@@ -47,19 +47,7 @@ common message formats such as Prometheus
    "api.key": "<NEW_RELIC_API_KEY>"
    }
   }
-    ```
-  where...
-  
-  | attribute     |                          description          |
-  | ------------- | --------------------------------------------- |
-  | name          | user definable name for identifying connector |
-  |connector.class| Fully qualified class name                    |
-  |value.converter| JSON convertor                                |
-  |value.converter.schemas.enable| false for no schema check      |
-  |topics         | Coma seperated list of topics the connector listens to.|
-  |api.key        | NR api key |
-  |max.retries        | (Optional) set max number of retries on the NR server, default is 5 |
-  |retry.interval.ms | (Optional) set interval between retries in milli seconds, default is 1000 |
+  ```
   
   
 - This will create the connector job. To check the list of running Connector jobs head over to http://localhost:8083/connectors
@@ -81,6 +69,21 @@ common message formats such as Prometheus
    }
   }
     ```
+### Full list of variables you can send to connector 
+  | attribute     | Required |                          description          |
+  | ------------- | -------- | --------------------------------------------- |
+  | name          | yes | user definable name for identifying connector |
+  |connector.class| yes | com.newrelic.telemetry.events.TelemetryEventsSinkConnector(Events) or com.newrelic.telemetry.events.TelemetryMetricsSinkConnector(Metrics)|
+  |value.converter| yes | com.newrelic.telemetry.events.EventsConverter(Events) or com.newrelic.telemetry.metrics.MetricsConverter(Metrics) |
+  |topics         | yes | Coma seperated list of topics the connector listens to.|
+  |api.key        | yes | NR api key |
+  |nr.max.retries | no  | set max number of retries on the NR server, default is 5 |
+  |nr.retry.interval.ms | no | set interval between retries in milli seconds, default is 1000 |
+  |errors.tolerance | no | all(ignores all json errors) or none(makes connector fail on messages with incorrect format) |
+  |errors.deadletterqueue.topic.name| no | dlq topic name ( messages with incorrect format are sent to this topic) |
+  |errors.deadletterqueue.topic.replication.factor| no | dlq topic replication factor |
+  
+  
 
 ### Simple Message Transforms 
 - Sometimes customers want to use their own message format which is different from the standard `events` or `metrics` format.

--- a/newrelic-kafka-connector/pom.xml
+++ b/newrelic-kafka-connector/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <kafka.version>2.5.0</kafka.version>
-        <junit.version>4.12</junit.version>
+        <junit.version>4.13</junit.version>
     </properties>
 
     <dependencies>
@@ -137,6 +137,11 @@
                             <dockerNamespace>confluentinc</dockerNamespace>
                             <dockerName>cp-kafka-connect</dockerName>
                             <dockerTag>${project.version}</dockerTag>
+                            <licenses>
+                                <license.name>Apache License, Version 2.0</license.name>
+                                <license.url>http://www.apache.org/licenses/LICENSE-2.0</license.url>
+
+                            </licenses>
 
                             <componentTypes>
                                 <componentType>sink</componentType>

--- a/newrelic-kafka-connector/src/main/java/com/newrelic/telemetry/TelemetrySinkConnectorConfig.java
+++ b/newrelic-kafka-connector/src/main/java/com/newrelic/telemetry/TelemetrySinkConnectorConfig.java
@@ -12,7 +12,11 @@ public class TelemetrySinkConnectorConfig extends AbstractConfig {
 
     public static final String API_KEY = "api.key";
     private static final String API_KEY_DOC = "API Key for New Relic.";
+    public static final String MAX_RETRIES = "nr.max.retries";
+    private static final String RETRIES_DOC = "Number of retries when New Relic servers are down.";
 
+    public static final String RETRY_INTERVAL_MS = "nr.retry.interval.ms";
+    private static final String RETRY_INTERVAL_MS_DOC = "Interval between reties in milliseconds.";
 
     public TelemetrySinkConnectorConfig(ConfigDef config, Map<String, String> parsedConfig) {
         super(config, parsedConfig);
@@ -24,8 +28,9 @@ public class TelemetrySinkConnectorConfig extends AbstractConfig {
 
     public static ConfigDef conf() {
         ConfigDef configDef = new ConfigDef()
-                .define(API_KEY, Type.PASSWORD, Importance.HIGH, API_KEY_DOC);
-
+                .define(API_KEY, Type.PASSWORD, Importance.HIGH, API_KEY_DOC)
+                .define(MAX_RETRIES, Type.INT, 5, Importance.LOW, RETRIES_DOC)
+                .define(RETRY_INTERVAL_MS, Type.LONG, 1000, Importance.LOW, RETRY_INTERVAL_MS_DOC);
         return configDef;
     }
 

--- a/newrelic-kafka-connector/src/main/java/com/newrelic/telemetry/TelemetrySinkConnectorConfig.java
+++ b/newrelic-kafka-connector/src/main/java/com/newrelic/telemetry/TelemetrySinkConnectorConfig.java
@@ -13,14 +13,6 @@ public class TelemetrySinkConnectorConfig extends AbstractConfig {
     public static final String API_KEY = "api.key";
     private static final String API_KEY_DOC = "API Key for New Relic.";
 
-    public static final String ACCOUNT_ID = "account.id";
-    private static final String ACCOUNT_ID_DOC = "Account ID for New Relic.";
-
-    public static final String MAX_RETRIES = "max.retries";
-    private static final String RETRIES_DOC = "Number of retries when New Relic servers are down.";
-
-    public static final String RETRY_INTERVAL_MS = "retry.interval.ms";
-    private static final String RETRY_INTERVAL_MS_DOC = "Interval between reties in milliseconds.";
 
     public TelemetrySinkConnectorConfig(ConfigDef config, Map<String, String> parsedConfig) {
         super(config, parsedConfig);
@@ -31,11 +23,8 @@ public class TelemetrySinkConnectorConfig extends AbstractConfig {
     }
 
     public static ConfigDef conf() {
-        ConfigDef.ValidString datatypeValidator = ConfigDef.ValidString.in("metric", "event");
         ConfigDef configDef = new ConfigDef()
-                .define(API_KEY, Type.PASSWORD, Importance.HIGH, API_KEY_DOC)
-                .define(MAX_RETRIES, Type.INT, 5, Importance.LOW, RETRIES_DOC)
-                .define(RETRY_INTERVAL_MS, Type.LONG, 1000, Importance.LOW, RETRY_INTERVAL_MS_DOC);
+                .define(API_KEY, Type.PASSWORD, Importance.HIGH, API_KEY_DOC);
 
         return configDef;
     }

--- a/newrelic-kafka-connector/src/main/java/com/newrelic/telemetry/events/TelemetryEventsSinkTask.java
+++ b/newrelic-kafka-connector/src/main/java/com/newrelic/telemetry/events/TelemetryEventsSinkTask.java
@@ -2,12 +2,11 @@ package com.newrelic.telemetry.events;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.newrelic.telemetry.*;
+import com.newrelic.telemetry.events.models.EventModel;
 import com.newrelic.telemetry.exceptions.DiscardBatchException;
 import com.newrelic.telemetry.exceptions.ResponseException;
 import com.newrelic.telemetry.exceptions.RetryWithBackoffException;
-import com.newrelic.telemetry.exceptions.RetryWithSplitException;
 import com.newrelic.telemetry.http.HttpPoster;
-import com.newrelic.telemetry.events.models.EventModel;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.errors.ConnectException;
@@ -132,10 +131,7 @@ public class TelemetryEventsSinkTask extends SinkTask {
         } catch (RetryWithBackoffException re) {
             log.error("New Relic down " + re.getMessage());
             throw new RetriableException(re);
-        } catch (RetryWithSplitException re) {
-            log.error("Message payload too large, try reducing poll interval: "+re.getMessage());
-            throw new ConnectException(re);
-        } catch (DiscardBatchException re) {
+        }  catch (DiscardBatchException re) {
             log.error("API key is probably not right : "+re.getMessage());
             throw new ConnectException(re);
         } catch (ResponseException re) {

--- a/newrelic-kafka-connector/src/main/java/com/newrelic/telemetry/metrics/MetricsConverter.java
+++ b/newrelic-kafka-connector/src/main/java/com/newrelic/telemetry/metrics/MetricsConverter.java
@@ -1,8 +1,6 @@
 package com.newrelic.telemetry.metrics;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.newrelic.telemetry.events.models.EventModel;
 import com.newrelic.telemetry.metrics.models.CountModel;
@@ -60,8 +58,8 @@ public class MetricsConverter implements Converter {
                     commons.remove("attributes");
                 for (Map<String, Object> dataValue : metrics) {
                     //dataValue = (Map<String, Object>) metrics.get("metrics");
-                    log.info("this is the attribute" + dataValue.get("attributes"));
-                    log.info("this is the type" + dataValue.get("type"));
+                    log.debug("this is the attribute" + dataValue.get("attributes"));
+                    log.debug("this is the type" + dataValue.get("type"));
                     if (commons != null)
                         dataValue.putAll(commons);
 

--- a/newrelic-kafka-connector/src/main/java/com/newrelic/telemetry/metrics/TelemetryMetricsSinkTask.java
+++ b/newrelic-kafka-connector/src/main/java/com/newrelic/telemetry/metrics/TelemetryMetricsSinkTask.java
@@ -5,7 +5,6 @@ import com.newrelic.telemetry.*;
 import com.newrelic.telemetry.exceptions.DiscardBatchException;
 import com.newrelic.telemetry.exceptions.ResponseException;
 import com.newrelic.telemetry.exceptions.RetryWithBackoffException;
-import com.newrelic.telemetry.exceptions.RetryWithSplitException;
 import com.newrelic.telemetry.http.HttpPoster;
 import com.newrelic.telemetry.metrics.models.CountModel;
 import com.newrelic.telemetry.metrics.models.GaugeModel;
@@ -173,9 +172,6 @@ public class TelemetryMetricsSinkTask extends SinkTask {
         } catch (RetryWithBackoffException re) {
             log.error("New Relic down " + re.getMessage());
             throw new RetriableException(re);
-        } catch (RetryWithSplitException re) {
-            log.error("Message payload too large, try reducing poll interval: "+re.getMessage());
-            throw new ConnectException(re);
         } catch (DiscardBatchException re) {
             log.error("API key is probably not right : "+re.getMessage());
             throw new ConnectException(re);

--- a/newrelic-kafka-connector/src/test/java/com/newrelic/telemetry/TelemetryMetricsSinkTaskTest.java
+++ b/newrelic-kafka-connector/src/test/java/com/newrelic/telemetry/TelemetryMetricsSinkTaskTest.java
@@ -5,23 +5,20 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.newrelic.telemetry.exceptions.ResponseException;
 import com.newrelic.telemetry.metrics.MetricBatch;
 import com.newrelic.telemetry.metrics.MetricBatchSender;
+import com.newrelic.telemetry.metrics.MetricsConverter;
 import com.newrelic.telemetry.metrics.TelemetryMetricsSinkTask;
+import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.*;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.*;
-import static org.junit.Assert.*;
 
 public class TelemetryMetricsSinkTaskTest {
-    /*TelemetryMetricsSinkTask sinkTask = new TelemetryMetricsSinkTask();
+    TelemetryMetricsSinkTask sinkTask = new TelemetryMetricsSinkTask();
     Map<String, String> configs = null;
     Response response = new Response(200, "Successful", null);
 
@@ -39,9 +36,7 @@ public class TelemetryMetricsSinkTaskTest {
         //sinkTask.mapper = mapper;
         configs = new HashMap<>();
         configs.put(TelemetrySinkConnectorConfig.API_KEY, "");
-        configs.put(TelemetrySinkConnectorConfig.ACCOUNT_ID, "123");
-        configs.put(TelemetrySinkConnectorConfig.MAX_RETRIES, "5");
-        configs.put(TelemetrySinkConnectorConfig.RETRY_INTERVAL_MS, "1000");
+
     }
 
     @Test
@@ -50,9 +45,9 @@ public class TelemetryMetricsSinkTaskTest {
         sinkTask.start(configs);
         sinkTask.sender = mock(MetricBatchSender.class);
         Collection<SinkRecord> records = new ArrayList<SinkRecord>();
-        List<Map<String, Object>> metricsList = mapper.readValue(metricCountJSON, List.class);
+        SchemaAndValue metricsList = new MetricsConverter().toConnectData(metricCountJSON, metricCountJSON.getBytes());
 
-        records.add(new SinkRecord("test", 0, null, null, null, metricsList, 0));
+        records.add(new SinkRecord("test", 0, null, null, null, metricsList.value(), 0));
         when(sinkTask.sender.sendBatch(any(MetricBatch.class))).thenReturn(response);
 
         sinkTask.put(records);
@@ -66,9 +61,10 @@ public class TelemetryMetricsSinkTaskTest {
         sinkTask.start(configs);
         sinkTask.sender = mock(MetricBatchSender.class);
         Collection<SinkRecord> records = new ArrayList<SinkRecord>();
-        List<Map<String, Object>> metricsList = mapper.readValue(metricCountGaugeSummaryJSON, List.class);
+        SchemaAndValue metricsList = new MetricsConverter().toConnectData(metricCountGaugeSummaryJSON, metricCountGaugeSummaryJSON.getBytes());
 
-        records.add(new SinkRecord("test", 0, null, null, null, metricsList, 0));
+
+        records.add(new SinkRecord("test", 0, null, null, null, metricsList.value(), 0));
         when(sinkTask.sender.sendBatch(any(MetricBatch.class))).thenReturn(response);
 
         sinkTask.put(records);
@@ -82,13 +78,14 @@ public class TelemetryMetricsSinkTaskTest {
         sinkTask.sender = mock(MetricBatchSender.class);
 
         Collection<SinkRecord> records = new ArrayList<SinkRecord>();
-        List<Map<String, Object>> metricsList = mapper.readValue(metricCountGaugeSummaryJSON, List.class);
+        SchemaAndValue metricsList = new MetricsConverter().toConnectData(metricWithCommonJSON, metricWithCommonJSON.getBytes());
 
-        records.add(new SinkRecord("test", 0, null, null, null, metricsList, 0));
+
+        records.add(new SinkRecord("test", 0, null, null, null, metricsList.value(), 0));
         when(sinkTask.sender.sendBatch(any(MetricBatch.class))).thenReturn(response);
 
         sinkTask.put(records);
         assertEquals(3, sinkTask.metricBatch.size());
 
-    }*/
+    }
 }

--- a/newrelic-kafka-connector/src/test/java/com/newrelic/telemetry/TelemetrySinkConnectorConfigTest.java
+++ b/newrelic-kafka-connector/src/test/java/com/newrelic/telemetry/TelemetrySinkConnectorConfigTest.java
@@ -8,7 +8,8 @@ public class TelemetrySinkConnectorConfigTest {
     @Test
     public void doc() {
         String stringConf = TelemetrySinkConnectorConfig.conf().toRst();
-        assertTrue(stringConf.contains("api.key"));
-
+        assertTrue(stringConf.contains(TelemetrySinkConnectorConfig.API_KEY));
+        assertTrue(stringConf.contains(TelemetrySinkConnectorConfig.RETRY_INTERVAL_MS));
+        assertTrue(stringConf.contains(TelemetrySinkConnectorConfig.MAX_RETRIES));
     }
 }

--- a/newrelic-kafka-connector/src/test/java/com/newrelic/telemetry/TelemetrySinkConnectorConfigTest.java
+++ b/newrelic-kafka-connector/src/test/java/com/newrelic/telemetry/TelemetrySinkConnectorConfigTest.java
@@ -9,7 +9,6 @@ public class TelemetrySinkConnectorConfigTest {
     public void doc() {
         String stringConf = TelemetrySinkConnectorConfig.conf().toRst();
         assertTrue(stringConf.contains("api.key"));
-        assertTrue(stringConf.contains("max.retries"));
-        assertTrue(stringConf.contains("retry.interval.ms"));
+
     }
 }


### PR DESCRIPTION
- fixed retry logic. For things like wrong api keys or too large batch there is no need to retry 
- prefixed the retry variables with nr to avoid confusion
- Changed some log levels from info to debug (https://github.com/newrelic/kafka-connect-newrelic/issues/20)
- fixed documentation
- added apache license (https://github.com/newrelic/kafka-connect-newrelic/issues/23)