### PR TITLE
Adding Logs Sink Connector and Global Sink Timeouts

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,25 @@
+# This workflow will build a Java project with Maven
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Java CI with Maven
+
+on:
+  push:
+    branches: [ master, adding-logs-sink-connector ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Build with Maven
+      working-directory: newrelic-kafka-connector
+      run: mvn -B clean package --file pom.xml

--- a/newrelic-kafka-connector/config/TelemetryEventsSinkConnector.properties
+++ b/newrelic-kafka-connector/config/TelemetryEventsSinkConnector.properties
@@ -1,0 +1,4 @@
+name=TelemetryEventsSinkConnector
+topics=mytopic
+tasks.max=1
+connector.class=com.newrelic.telemetry.events.TelemetryEventsSinkConnector

--- a/newrelic-kafka-connector/config/TelemetryLogsSinkConnector.properties
+++ b/newrelic-kafka-connector/config/TelemetryLogsSinkConnector.properties
@@ -1,0 +1,6 @@
+name=TelemetryLogsSinkConnector
+connector.class=com.newrelic.telemetry.logs.TelemetryLogsSinkConnector
+topics=log_events
+tasks.max=1
+nr.timeout=10
+value.converter=com.newrelic.telemetry.logs.LogsConverter

--- a/newrelic-kafka-connector/pom.xml
+++ b/newrelic-kafka-connector/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.newrelic.telemetry</groupId>
     <artifactId>newrelic-kafka-connector</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Kafka-connect-new-relic</name>
@@ -43,13 +43,13 @@
         </dependency>
         <dependency>
             <groupId>com.newrelic.telemetry</groupId>
-            <artifactId>telemetry</artifactId>
-            <version>0.6.1</version>
+            <artifactId>telemetry-core</artifactId>
+            <version>0.12.0</version>
         </dependency>
         <dependency>
             <groupId>com.newrelic.telemetry</groupId>
             <artifactId>telemetry-http-okhttp</artifactId>
-            <version>0.6.1</version>
+            <version>0.12.0</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-api -->
         <dependency>

--- a/newrelic-kafka-connector/src/main/java/com/newrelic/telemetry/TelemetrySinkConnectorConfig.java
+++ b/newrelic-kafka-connector/src/main/java/com/newrelic/telemetry/TelemetrySinkConnectorConfig.java
@@ -16,10 +16,21 @@ public class TelemetrySinkConnectorConfig extends AbstractConfig {
     private static final String RETRIES_DOC = "Number of retries when New Relic servers are down.";
 
     public static final String RETRY_INTERVAL_MS = "nr.retry.interval.ms";
-    private static final String RETRY_INTERVAL_MS_DOC = "Interval between reties in milliseconds.";
+    private static final String RETRY_INTERVAL_MS_DOC = "Interval between retries in milliseconds.";
+
+    public static final String USE_RECORD_TIMESTAMP = "use.record.timestamp";    
+    private static final String USE_RECORD_TIMESTAMP_DOC = "When set to `true`, The timestamp "
+    + "is retrieved from the Kafka record and passed to New Relic. When set to false, the timestamp will be the ingestion timestamp. By "
+    + "default, this is set to true.";
+
+    public static final String TIMEOUT_SECONDS = "nr.timeout";
+    private static final String TIMEOUT_SECONDS_DOC = "Timeout for API calls in seconds. By default, this is set to 2 seconds";
+
+    public final boolean useRecordTimestamp;
 
     public TelemetrySinkConnectorConfig(ConfigDef config, Map<String, String> parsedConfig) {
         super(config, parsedConfig);
+        useRecordTimestamp = getBoolean(USE_RECORD_TIMESTAMP);
     }
 
     public TelemetrySinkConnectorConfig(Map<String, String> parsedConfig) {
@@ -29,6 +40,8 @@ public class TelemetrySinkConnectorConfig extends AbstractConfig {
     public static ConfigDef conf() {
         ConfigDef configDef = new ConfigDef()
                 .define(API_KEY, Type.PASSWORD, Importance.HIGH, API_KEY_DOC)
+                .define(USE_RECORD_TIMESTAMP, ConfigDef.Type.BOOLEAN, true, ConfigDef.Importance.MEDIUM, USE_RECORD_TIMESTAMP_DOC)
+                .define(TIMEOUT_SECONDS, Type.INT, 2, Importance.LOW, TIMEOUT_SECONDS_DOC)
                 .define(MAX_RETRIES, Type.INT, 5, Importance.LOW, RETRIES_DOC)
                 .define(RETRY_INTERVAL_MS, Type.LONG, 1000, Importance.LOW, RETRY_INTERVAL_MS_DOC);
         return configDef;

--- a/newrelic-kafka-connector/src/main/java/com/newrelic/telemetry/logs/LogBuffer.java
+++ b/newrelic-kafka-connector/src/main/java/com/newrelic/telemetry/logs/LogBuffer.java
@@ -1,0 +1,77 @@
+package com.newrelic.telemetry.logs;
+
+import com.newrelic.telemetry.Attributes;
+import com.newrelic.telemetry.util.Utils;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class LogBuffer {
+  private static final Logger logger = LoggerFactory.getLogger(LogBuffer.class);
+
+  private final Queue<Log> logs = new ConcurrentLinkedQueue<>();
+
+  private final Attributes commonAttributes;
+
+  public LogBuffer(Attributes commonAttributes) {
+    this.commonAttributes = Utils.verifyNonNull(commonAttributes);
+  }
+
+  public void addLog(Log log) {
+    logs.add(log);
+  }
+
+  public int size() {
+    return logs.size();
+  }
+
+  public LogBatch createBatch() {
+    logger.debug("Creating Log batch. Size: "+this.logs.size());
+    Collection<Log> logsForBatch = new ArrayList<>(this.logs.size());
+
+    // Drain the Log buffer and return the batch
+    Log log;
+    while ((log = this.logs.poll()) != null) {
+      logsForBatch.add(log);
+    }
+
+    return new LogBatch(logsForBatch, this.commonAttributes);
+  }
+
+  Queue<Log> getLogs() {
+    return logs;
+  }
+
+  Attributes getCommonAttributes() {
+    return commonAttributes;
+  }
+
+  @Override
+  public String toString() {
+    return "LogBuffer{" + "log=" + logs + ", commonAttributes=" + commonAttributes + '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    LogBuffer that = (LogBuffer) o;
+
+    if (getLogs() != null ? !getLogs().equals(that.getLogs()) : that.getLogs() != null)
+      return false;
+    return getCommonAttributes() != null
+        ? getCommonAttributes().equals(that.getCommonAttributes())
+        : that.getCommonAttributes() == null;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = getLogs() != null ? getLogs().hashCode() : 0;
+    result = 31 * result + (getCommonAttributes() != null ? getCommonAttributes().hashCode() : 0);
+    return result;
+  }
+}

--- a/newrelic-kafka-connector/src/main/java/com/newrelic/telemetry/logs/LogsConverter.java
+++ b/newrelic-kafka-connector/src/main/java/com/newrelic/telemetry/logs/LogsConverter.java
@@ -1,0 +1,56 @@
+package com.newrelic.telemetry.logs;
+
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.newrelic.telemetry.logs.models.LogModel;
+import org.apache.kafka.common.errors.SerializationException;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.storage.Converter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Map;
+
+public class LogsConverter implements Converter {
+    private static Logger log = LoggerFactory.getLogger(LogsConverter.class);
+
+    @Override
+    public void configure(Map<String, ?> map, boolean b) {
+
+    }
+
+    @Override
+    public byte[] fromConnectData(String topic, Schema schema, Object value) {
+        List<LogModel> eventModels = (List<LogModel>)value;
+        try {
+            return new ObjectMapper().writeValueAsString(eventModels).getBytes();
+        } catch (JsonProcessingException e) {
+            log.error("Error while serializing events");
+            return new byte[0];
+        }
+
+    }
+
+    @Override
+    public SchemaAndValue toConnectData(String topic, byte[] bytes) {
+        try {
+            String value = new String(bytes);
+            ObjectMapper mapper = new ObjectMapper();
+            mapper.configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true);
+            mapper.setSerializationInclusion(Include.NON_NULL);
+            List<LogModel> events = mapper.readValue(value, new TypeReference<List<LogModel>>() {
+            });
+            final SchemaAndValue obj = new SchemaAndValue(null, events);
+            return (obj);
+        }  catch (Exception e) {
+            log.error("Error while deserializing events " + e.getMessage());
+            throw new SerializationException(e.getMessage());
+        }
+
+    }
+}

--- a/newrelic-kafka-connector/src/main/java/com/newrelic/telemetry/logs/TelemetryLogsSinkConnector.java
+++ b/newrelic-kafka-connector/src/main/java/com/newrelic/telemetry/logs/TelemetryLogsSinkConnector.java
@@ -1,0 +1,56 @@
+package com.newrelic.telemetry.logs;
+
+import com.newrelic.telemetry.TelemetrySinkConnectorConfig;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.connector.Task;
+import org.apache.kafka.connect.sink.SinkConnector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class TelemetryLogsSinkConnector extends SinkConnector {
+    private static Logger log = LoggerFactory.getLogger(TelemetryLogsSinkConnector.class);
+    private TelemetrySinkConnectorConfig config;
+    private Map<String, String> configProps = new HashMap<>();
+
+    @Override
+    public String version() {
+        return "1.0.0";
+    }
+
+    @Override
+    public void start(Map<String, String> props) {
+        configProps = props;
+    }
+
+    @Override
+    public Class<? extends Task> taskClass() {
+        //TODO: Return your task implementation.
+        return TelemetryLogsSinkTask.class;
+    }
+
+    @Override
+    public List<Map<String, String>> taskConfigs(int maxTasks) {
+
+        final List<Map<String, String>> configs = new ArrayList<>(maxTasks);
+        for (int i = 0; i < maxTasks; ++i) {
+            configs.add(configProps);
+        }
+
+        return configs;
+    }
+
+    @Override
+    public void stop() {
+        //TODO: Do things that are necessary to stop your connector.
+    }
+
+    @Override
+    public ConfigDef config() {
+        return TelemetrySinkConnectorConfig.conf();
+    }
+}

--- a/newrelic-kafka-connector/src/main/java/com/newrelic/telemetry/logs/TelemetryLogsSinkTask.java
+++ b/newrelic-kafka-connector/src/main/java/com/newrelic/telemetry/logs/TelemetryLogsSinkTask.java
@@ -1,0 +1,201 @@
+package com.newrelic.telemetry.logs;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.newrelic.telemetry.*;
+import com.newrelic.telemetry.logs.models.LogModel;
+import com.newrelic.telemetry.exceptions.DiscardBatchException;
+import com.newrelic.telemetry.exceptions.ResponseException;
+import com.newrelic.telemetry.exceptions.RetryWithBackoffException;
+import com.newrelic.telemetry.http.HttpPoster;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.errors.RetriableException;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.apache.kafka.connect.sink.SinkTask;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+public class TelemetryLogsSinkTask extends SinkTask {
+    private static Logger logger = LoggerFactory.getLogger(TelemetryLogsSinkTask.class);
+    String apiKey = null;
+    int retries;
+    int timeout;    
+    long retryInterval;
+    boolean useRecordTimestamp;    
+    private TelemetrySinkConnectorConfig connectorConfig;
+    public LogBatchSender logSender = null;
+    public String NRURL="https://log-api.newrelic.com/log/v1";
+    public int retriedCount;
+    LogBuffer logBuffer = null;
+
+    public LogBatch logBatch = null;
+
+    ObjectMapper mapper = null;
+
+
+    @Override
+    public String version() {
+        return "1.0.0";
+    }
+
+
+    @Override
+    public void start(Map<String, String> map) {
+        connectorConfig = new TelemetrySinkConnectorConfig(map);
+        useRecordTimestamp = connectorConfig.useRecordTimestamp;
+        apiKey = map.get(TelemetrySinkConnectorConfig.API_KEY);
+        retries = map.get(TelemetrySinkConnectorConfig.MAX_RETRIES) != null ? Integer.parseInt(map.get(TelemetrySinkConnectorConfig.MAX_RETRIES)) : (Integer) TelemetrySinkConnectorConfig.conf().defaultValues().get(TelemetrySinkConnectorConfig.MAX_RETRIES);
+        retryInterval = map.get(TelemetrySinkConnectorConfig.RETRY_INTERVAL_MS) != null ? Long.parseLong(map.get(TelemetrySinkConnectorConfig.RETRY_INTERVAL_MS)) : (Long) TelemetrySinkConnectorConfig.conf().defaultValues().get(TelemetrySinkConnectorConfig.RETRY_INTERVAL_MS);
+        timeout = map.get(TelemetrySinkConnectorConfig.TIMEOUT_SECONDS) != null ? Integer.parseInt(map.get(TelemetrySinkConnectorConfig.TIMEOUT_SECONDS)) : (Integer) TelemetrySinkConnectorConfig.conf().defaultValues().get(TelemetrySinkConnectorConfig.TIMEOUT_SECONDS);        
+
+        mapper = new ObjectMapper();
+
+        try {
+            LogBatchSenderFactory logFactory = LogBatchSenderFactory.fromHttpImplementation((Supplier<HttpPoster>) OkHttpPoster::new);
+            logSender = LogBatchSender.create(logFactory.configureWith(apiKey).endpoint(new URL(NRURL)).auditLoggingEnabled(true).httpPoster(new OkHttpPoster(Duration.ofSeconds(timeout))).build());                
+            logBuffer = new LogBuffer(new Attributes());
+        } catch (MalformedURLException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private Attributes buildAttributes(Map<String, Object> atts) {
+        Attributes attributes = new Attributes();
+        atts.keySet().forEach(key -> {
+            Object attributeValue = atts.get(key);
+            if (attributeValue instanceof String)
+                attributes.put(key, (String) attributeValue);
+            else if (attributeValue instanceof Number)
+                attributes.put(key, (Number) attributeValue);
+            else if (attributeValue instanceof Boolean)
+                attributes.put(key, (Boolean) attributeValue);
+            // Value is nested JSON
+            else if (attributeValue instanceof LinkedHashMap) {
+                try {
+                    attributes.put(key, new ObjectMapper().writeValueAsString(attributeValue));
+                } catch (JsonProcessingException e) {
+                    //e.printStackTrace();
+                    attributes.put(key, (String) attributeValue.toString());
+                }
+            }
+            else if (attributeValue instanceof ArrayList) {
+                // Changing ArrayList to a comma separated string
+                String values;
+                try {
+                    values = new ObjectMapper().writeValueAsString(attributeValue);
+                    values = values.substring(1, (values.length()-1)-1);
+                    attributes.put(key, values);
+                } catch (JsonProcessingException e) {
+                    // e.printStackTrace();
+                    attributes.put(key, (String) attributeValue.toString());
+                }
+            }
+        });
+        return attributes;
+    }
+
+
+    @Override
+    public void put(Collection<SinkRecord> records) {
+        for (SinkRecord record : records) {
+            try {
+                logger.debug("got back record " + record.toString());
+                List<LogModel> dataValues = (List<LogModel>) record.value();
+                dataValues.forEach(logModel -> {
+                    Attributes attributes = buildAttributes(logModel.fields());
+                    long timestamp;
+                    Map<String, Object> map = attributes.asMap();                    
+                    if(!map.containsKey("timestamp")) {
+                        timestamp = System.currentTimeMillis();
+                        if (connectorConfig.useRecordTimestamp && record.timestamp() != null) {
+                            logger.debug("Using Record Timestamp: "+(long)(record.timestamp()));
+                            timestamp = (long)(record.timestamp() / 1000.0); 
+                        }    
+                    } else {
+                        timestamp = Long.parseLong((String)map.get("timestamp"));
+                        logger.debug("Using timestamp found in log line: "+timestamp);                        
+                    }
+
+                    Log log = Log.builder()
+                    .attributes(attributes)
+                    .timestamp(timestamp)
+                    .build();
+                    logBuffer.addLog(log);
+                });
+            } catch (IllegalArgumentException ie) {
+                logger.error(ie.getMessage());
+                //throw ie;
+                continue;
+            }
+        }
+        if(!logBuffer.getLogs().isEmpty()) {
+            retriedCount = 0;
+
+                while (retriedCount++ < retries - 1) {
+                    try {
+                        logBatch = logBuffer.createBatch();
+                        sendToNewRelic();
+                        break;
+                    }  catch(RetriableException re) {
+                        logger.error("Retrying for "+retriedCount+" time");
+                        try {
+                            Thread.sleep(retryInterval);
+                        } catch (InterruptedException e) {
+                            logger.error("Retry Sleep thread was interrupted");
+                        }
+
+                    }
+                }
+                if(retriedCount==retries)
+                    throw new ConnectException("failed to connect to new relic after retries "+retriedCount);
+            }
+
+        }
+
+
+    private void sendToNewRelic() {
+        try {
+            Response response = null;
+            logger.debug("logBatch (Size:"+logBatch.size()+") to be sent: "+ logBatch);
+            response = logSender.sendBatch(logBatch);
+            logger.debug("Response from new relic " + response);
+            if (!(response.getStatusCode() == 200 || response.getStatusCode() == 202)) {
+                logger.error("New Relic sent back error " + response.getStatusMessage());
+                throw new RetriableException(response.getStatusMessage());
+            }
+        } catch (RetryWithBackoffException re) {
+            logger.error("New Relic down " + re.getMessage()+"\nCurrent Batch : "+logBatch);
+            throw new RetriableException(re);
+        }  catch (DiscardBatchException re) {
+            logger.error("DiscardBatchException : Make sure api.key is set to an Insights Insert Key. https://bit.ly/3cAvFVp Key: "+apiKey+" "+re.getMessage()+"\nBad Batch : "+logBatch.getTelemetry());
+            throw new ConnectException(re);
+        } catch (ResponseException re) {
+            logger.error("ResponseException : "+re.getMessage()+"\nBad Batch : "+logBatch);
+            throw new ConnectException(re);
+        }
+    }
+
+
+    @Override
+    public void flush(Map<TopicPartition, OffsetAndMetadata> map) {
+        super.flush(map);
+    }
+
+    @Override
+    public void stop() {
+        //Close resources here.
+    }
+
+}

--- a/newrelic-kafka-connector/src/main/java/com/newrelic/telemetry/logs/models/LogModel.java
+++ b/newrelic-kafka-connector/src/main/java/com/newrelic/telemetry/logs/models/LogModel.java
@@ -1,0 +1,28 @@
+package com.newrelic.telemetry.logs.models;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class LogModel {
+
+    Map<String, Object> attributes = new HashMap<>();
+
+    // Capture all fields
+    @JsonAnyGetter
+    public Map<String, Object> fields() {
+        return attributes;
+    }
+
+    @JsonAnySetter
+    public void setField(String name, Object value) {
+        attributes.put(name, value);
+    }
+
+    @Override
+    public String toString() {
+      return "LogModel{" + attributes + '}';
+    }
+}

--- a/newrelic-kafka-connector/src/test/java/com/newrelic/telemetry/LogsConverterTest.java
+++ b/newrelic-kafka-connector/src/test/java/com/newrelic/telemetry/LogsConverterTest.java
@@ -1,0 +1,23 @@
+package com.newrelic.telemetry;
+
+import com.newrelic.telemetry.logs.LogsConverter;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.junit.Test;
+
+public class LogsConverterTest {
+    private static final String logsJSON =            "{ \"key1\": \"value1\", \"key2\": \"value2\", \"key3\": \"value3\"}";
+    private static final String logsJSONNestedValue = "{ \"key1\": \"value1\", \"key2\": \"value2\", \"key3\": \"value3\", \"nestedkey\": {\"key1\": \"value4\",\"key2\": \"value5\"}}";
+
+    @Test
+    public void toConnectData() {
+        SchemaAndValue schemaAndValue = new LogsConverter().toConnectData("", logsJSON.getBytes());
+        System.out.println(schemaAndValue.value());
+    }
+
+    @Test
+    public void toConnectDataWithNestedValues() {
+        SchemaAndValue schemaAndValue = new LogsConverter().toConnectData("", logsJSONNestedValue.getBytes());
+        System.out.println(schemaAndValue.value());
+
+    }    
+}

--- a/newrelic-kafka-connector/src/test/java/com/newrelic/telemetry/TelemetryLogsSinkTaskTest.java
+++ b/newrelic-kafka-connector/src/test/java/com/newrelic/telemetry/TelemetryLogsSinkTaskTest.java
@@ -1,0 +1,146 @@
+package com.newrelic.telemetry;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.newrelic.telemetry.logs.Log;
+import com.newrelic.telemetry.logs.LogBatch;
+import com.newrelic.telemetry.logs.LogBatchSender;
+import com.newrelic.telemetry.logs.LogsConverter;
+import com.newrelic.telemetry.logs.TelemetryLogsSinkTask;
+import com.newrelic.telemetry.exceptions.ResponseException;
+
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+
+public class TelemetryLogsSinkTaskTest {
+    TelemetryLogsSinkTask sinkTask = new TelemetryLogsSinkTask();
+    Map<String, String> configs = null;
+    Response response = new Response(200, "Successful", null);
+    ObjectMapper mapper = new ObjectMapper();
+
+    private static final String logsJSON =            "{ \"key1\": \"value1\", \"key2\": \"value2\", \"key3\": \"value3\"}";
+    private static final long TEST_TIMESTAMP = 1616638651294L;
+    private static final String logsJSONTimestamp =   "{ \"key1\": \"value1\", \"key2\": \"value2\", \"key3\": \"value3\" , \"timestamp\": \""+TEST_TIMESTAMP+"\"}";    
+    private static final String logsJSONNestedValue = "{ \"key1\": \"value1\", \"key2\": \"value2\", \"key3\": \"value3\", \"nestedkey\": {\"key1\": \"value4\",\"key2\": \"value5\"}}";
+
+    private long logTimestamp = 0L;
+
+    @Before
+    public void init() {
+        //sinkTask.mapper = mapper;
+        configs = new HashMap<>();
+        configs.put(TelemetrySinkConnectorConfig.API_KEY, "");
+    }
+
+
+  @Test
+  public void testPutEvent() throws ResponseException{
+
+    sinkTask.start(configs);
+    sinkTask.logSender = mock(LogBatchSender.class);
+
+    Collection<SinkRecord> records = new ArrayList<SinkRecord>();
+    SchemaAndValue  events =  new LogsConverter().toConnectData(logsJSON, logsJSON.getBytes());
+
+    records.add(new SinkRecord("test",0,null, null, null, events.value(), 0 ));
+
+    when(sinkTask.logSender.sendBatch(any(LogBatch.class))).thenReturn(response);
+
+    sinkTask.put(records);
+
+    assertEquals(1, sinkTask.logBatch.size());
+
+  }
+  
+  @Test
+  public void testPutEventWithNestedValue() throws ResponseException{
+
+    sinkTask.start(configs);
+    sinkTask.logSender = mock(LogBatchSender.class);
+
+    Collection<SinkRecord> records = new ArrayList<SinkRecord>();
+    SchemaAndValue  events =  new LogsConverter().toConnectData(logsJSONNestedValue, logsJSONNestedValue.getBytes());
+
+    records.add(new SinkRecord("test",0,null, null, null, events.value(), 0 ));
+
+    when(sinkTask.logSender.sendBatch(any(LogBatch.class))).thenReturn(response);
+
+    sinkTask.put(records);
+
+    assertEquals(1, sinkTask.logBatch.size());
+    Collection<Log> logs = (Collection<Log>)(sinkTask.logBatch).getTelemetry();
+    logs.forEach(log -> {
+      Map<String, Object> attr= log.getAttributes().asMap();
+      assertEquals((String) attr.get("nestedkey"), "{\"key1\":\"value4\",\"key2\":\"value5\"}"); 
+    });
+
+  } 
+  
+  @Test
+  public void testPutEventWithTimestamp() throws ResponseException{
+    sinkTask.start(configs);
+    sinkTask.logSender = mock(LogBatchSender.class);
+
+    Collection<SinkRecord> records = new ArrayList<SinkRecord>();
+    SchemaAndValue  events =  new LogsConverter().toConnectData(logsJSONTimestamp, logsJSONTimestamp.getBytes());
+
+    records.add(new SinkRecord("test",0,null, null, null, events.value(), 0 ));
+
+    when(sinkTask.logSender.sendBatch(any(LogBatch.class))).thenReturn(response);
+
+    sinkTask.put(records);
+
+    Collection<Log> logs = (Collection<Log>)(sinkTask.logBatch).getTelemetry();
+    logs.forEach(log -> {
+      logTimestamp = log.getTimestamp();
+    });
+
+    assertEquals(1, sinkTask.logBatch.size());
+    assertEquals(logTimestamp, TEST_TIMESTAMP);
+  } 
+
+  @Test
+  public void testPutEventWithBadNRURL()  {
+    sinkTask.NRURL="https://log-api.newrelic.com12/log/v1";
+    sinkTask.start(configs);
+
+    Collection<SinkRecord> records = new ArrayList<SinkRecord>();
+    SchemaAndValue  events =  new LogsConverter().toConnectData(logsJSON, logsJSON.getBytes());
+
+    records.add(new SinkRecord("test",0,null, null, null, events.value(), 0 ));
+
+    try{
+        sinkTask.put(records);
+    } catch (ConnectException ce) {
+        assertEquals(ce.getMessage(), "failed to connect to new relic after retries 5");
+    }
+  }
+
+    @Test
+    public void testPutEventWithBadNRURLWithDifferentRetries()  {
+        sinkTask.NRURL="https://log-api.newrelic.com12/log/v1";
+        configs.put(TelemetrySinkConnectorConfig.MAX_RETRIES,"3");
+        sinkTask.start(configs);
+
+        Collection<SinkRecord> records = new ArrayList<SinkRecord>();
+        SchemaAndValue  events =  new LogsConverter().toConnectData(logsJSON, logsJSON.getBytes());;
+
+        records.add(new SinkRecord("test",0,null, null, null, events.value(), 0 ));
+
+        try{
+            sinkTask.put(records);
+        } catch (ConnectException ce) {
+            assertEquals(ce.getMessage(), "failed to connect to new relic after retries 3");
+        }
+    }
+}


### PR DESCRIPTION
* Adding new Logs Sink Connector for sending Kafka messages to New Relic Logs.
* Added new `nr.timeout` parameter for all connectors. Default is 2 seconds.
* Updating Telemetry SDK version from 0.6.0 to 0.12.0
* Added simple GitHub action that runs tests on commits and PR's