### PR TITLE
Support configuring the New Relic data region in the connector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.3.0 (2022-05-09)
+### Added
+- Added new `nr.region` parameter to specify the New Relic data region. Default is `US`.
+
+### Changed
+ - Updating [Telemetry SDK](https://github.com/newrelic/newrelic-telemetry-sdk-java) version to 0.13.1
+
 ## 1.1.0 (2021-04-14)
 ### Added
 - Adding new Logs Sink Connector for sending Kafka messages to New Relic Logs.

--- a/newrelic-kafka-connector/README.md
+++ b/newrelic-kafka-connector/README.md
@@ -65,6 +65,7 @@ See the New Relic Metrics [API doucmentation](https://docs.newrelic.com/docs/tel
   |connector.class| yes | com.newrelic.telemetry.events.EventsSinkConnector(Events), com.newrelic.telemetry.metrics.MetricsSinkConnector(Metrics), or com.newrelic.telemetry.logs.LogsSinkConnector(Logs)|
   |topics         | yes | Comma seperated list of topics the connector listens to.|
   |api.key        | yes | NR api key |
+  |nr.region      | no  | NR data region, either US or EU (default: US) |
   |nr.client.timeout | no | Time, in milliseconds, to wait for a response from the New Relic API (default is 2000)|
   |nr.client.proxy.host| no | Proxy host to use to connect to the New Relic API |
   |nr.client.proxt.port | no | Proxy host to use to connect to the New Relic API (required if using a proxy host) | 

--- a/newrelic-kafka-connector/pom.xml
+++ b/newrelic-kafka-connector/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.newrelic.telemetry</groupId>
     <artifactId>newrelic-kafka-connector</artifactId>
-    <version>2.1.0</version>
+    <version>2.3.0</version>
     <packaging>jar</packaging>
 
     <name>Kafka-connect-new-relic</name>
@@ -44,12 +44,12 @@
         <dependency>
             <groupId>com.newrelic.telemetry</groupId>
             <artifactId>telemetry-core</artifactId>
-            <version>0.12.0</version>
+            <version>0.13.1</version>
         </dependency>
         <dependency>
             <groupId>com.newrelic.telemetry</groupId>
             <artifactId>telemetry-http-okhttp</artifactId>
-            <version>0.12.0</version>
+            <version>0.13.1</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-api -->
         <dependency>

--- a/newrelic-kafka-connector/src/main/java/com/newrelic/telemetry/TelemetrySinkConnector.java
+++ b/newrelic-kafka-connector/src/main/java/com/newrelic/telemetry/TelemetrySinkConnector.java
@@ -17,7 +17,7 @@ public abstract class TelemetrySinkConnector extends SinkConnector {
 
     @Override
     public String version() {
-        return "2.1.0";
+        return "2.3.0";
     }
 
     @Override

--- a/newrelic-kafka-connector/src/main/java/com/newrelic/telemetry/TelemetrySinkConnectorConfig.java
+++ b/newrelic-kafka-connector/src/main/java/com/newrelic/telemetry/TelemetrySinkConnectorConfig.java
@@ -13,6 +13,9 @@ public class TelemetrySinkConnectorConfig extends AbstractConfig {
     public static final String API_KEY = "api.key";
     private static final String API_KEY_DOC = "API Key for New Relic.";
 
+    public static final String NR_REGION = "nr.region";
+    private static final String NR_REGION_DOC = "Data region for New Relic, either US or EU (default is US)";
+
     public static final String NR_CLIENT_PROXY_HOST = "nr.client.proxy.host";
     private static final String NR_CLIENT_PROXY_HOST_DOC = "Proxy host to use to connect to the New Relic API";
 
@@ -40,6 +43,7 @@ public class TelemetrySinkConnectorConfig extends AbstractConfig {
     public static ConfigDef conf() {
         ConfigDef configDef = new ConfigDef()
                 .define(API_KEY, Type.PASSWORD, Importance.HIGH, API_KEY_DOC)
+                .define(NR_REGION, Type.STRING, "US", ConfigDef.ValidString.in("US", "EU"), Importance.LOW, NR_REGION_DOC)
                 .define(NR_CLIENT_TIMEOUT_MS, Type.INT, 2000, Importance.LOW, NR_CLIENT_TIMEOUT_MS_DOC)
                 .define(NR_CLIENT_PROXY_HOST, Type.STRING, null, Importance.LOW, NR_CLIENT_PROXY_HOST_DOC)
                 .define(NR_CLIENT_PROXY_PORT, Type.INT, null, Importance.LOW, NR_CLIENT_PROXY_PORT_DOC)


### PR DESCRIPTION
A new connector property, `nr.region`, can be used to choose New Relic data
region. By default `US` is used.

In order to be able to configure the data region in the telemetry client, the
`newrelic-telemetry-java-sdk` lbirary had to be updated to `0.13.1`.