### PR TITLE
Security updates for dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.3.1 (2022-09-20)
+### Changed
+ - Updated [Telemetry SDK](https://github.com/newrelic/newrelic-telemetry-sdk-java) version to 0.15
+ - Updated jackson-databind to 2.12.6.1
+ - Updated junit to 4.13.1
+ - Updated slf4j-api to 1.7.36
+
 ## 2.3.0 (2022-05-09)
 ### Added
 - Added new `nr.region` parameter to specify the New Relic data region. Default is `US`.

--- a/newrelic-kafka-connector/pom.xml
+++ b/newrelic-kafka-connector/pom.xml
@@ -44,12 +44,12 @@
         <dependency>
             <groupId>com.newrelic.telemetry</groupId>
             <artifactId>telemetry-core</artifactId>
-            <version>0.13.1</version>
+            <version>0.15.0</version>
         </dependency>
         <dependency>
             <groupId>com.newrelic.telemetry</groupId>
             <artifactId>telemetry-http-okhttp</artifactId>
-            <version>0.13.1</version>
+            <version>0.15.0</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-api -->
         <dependency>

--- a/newrelic-kafka-connector/pom.xml
+++ b/newrelic-kafka-connector/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.11.0</version>
+            <version>[2.12.6.1,)</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/newrelic-kafka-connector/pom.xml
+++ b/newrelic-kafka-connector/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>[2.12.6.1,)</version>
+            <version>2.12.6.1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/newrelic-kafka-connector/pom.xml
+++ b/newrelic-kafka-connector/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.newrelic.telemetry</groupId>
     <artifactId>newrelic-kafka-connector</artifactId>
-    <version>2.3.0</version>
+    <version>2.3.1</version>
     <packaging>jar</packaging>
 
     <name>Kafka-connect-new-relic</name>

--- a/newrelic-kafka-connector/pom.xml
+++ b/newrelic-kafka-connector/pom.xml
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.30</version>
+            <version>1.7.36</version>
         </dependency>
 
     </dependencies>

--- a/newrelic-kafka-connector/pom.xml
+++ b/newrelic-kafka-connector/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <kafka.version>2.5.0</kafka.version>
-        <junit.version>4.13</junit.version>
+        <junit.version>4.13.1</junit.version>
     </properties>
 
     <dependencies>

--- a/smts/newrelic-rollup-smt/pom.xml
+++ b/smts/newrelic-rollup-smt/pom.xml
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.30</version>
+            <version>1.7.36</version>
         </dependency>
 
     </dependencies>

--- a/smts/newrelic-rollup-smt/pom.xml
+++ b/smts/newrelic-rollup-smt/pom.xml
@@ -14,7 +14,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <kafka.version>2.0.0</kafka.version>
-        <junit.version>4.12</junit.version>
+        <junit.version>4.13.1</junit.version>
     </properties>
 
     <dependencies>

--- a/smts/newrelic-statsd-smt/pom.xml
+++ b/smts/newrelic-statsd-smt/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>[2.12.6.1,)</version>
+            <version>2.12.6.1</version>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-api -->

--- a/smts/newrelic-statsd-smt/pom.xml
+++ b/smts/newrelic-statsd-smt/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <kafka.version>2.5.0</kafka.version>
-        <junit.version>4.12</junit.version>
+        <junit.version>4.13.1</junit.version>
     </properties>
 
     <dependencies>

--- a/smts/newrelic-statsd-smt/pom.xml
+++ b/smts/newrelic-statsd-smt/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.30</version>
+            <version>1.7.36</version>
         </dependency>
 
     </dependencies>

--- a/smts/newrelic-statsd-smt/pom.xml
+++ b/smts/newrelic-statsd-smt/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.11.0</version>
+            <version>[2.12.6.1,)</version>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-api -->


### PR DESCRIPTION
Addresses issues in junit, jackson-databind, kotlin-stdlib

Maven builds and tests run (under Java 11) for all three projects in the repo, but have not actually tested it and did not increment the package version.