### PR TITLE
Update newrelic-telemetry-sdk-java (addresses CVE-2023-3635)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.3.3 (2024-04-10)
+### Changed
+ - Updated [Telemetry SDK](https://github.com/newrelic/newrelic-telemetry-sdk-java) to 0.16.0 (CVE-2023-3635)
+
 ## 2.3.2 (2022-10-24)
 ### Changed
  - Updated jackson-databind to 2.13.4.2 (CVE-2022-42003,CVE-2022-42004)

--- a/newrelic-kafka-connector/pom.xml
+++ b/newrelic-kafka-connector/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.newrelic.telemetry</groupId>
     <artifactId>newrelic-kafka-connector</artifactId>
-    <version>2.3.2</version>
+    <version>2.3.3</version>
     <packaging>jar</packaging>
 
     <name>Kafka-connect-new-relic</name>
@@ -44,12 +44,12 @@
         <dependency>
             <groupId>com.newrelic.telemetry</groupId>
             <artifactId>telemetry-core</artifactId>
-            <version>0.15.0</version>
+            <version>0.16.0</version>
         </dependency>
         <dependency>
             <groupId>com.newrelic.telemetry</groupId>
             <artifactId>telemetry-http-okhttp</artifactId>
-            <version>0.15.0</version>
+            <version>0.16.0</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-api -->
         <dependency>


### PR DESCRIPTION
Addresses transitive dependency on vulnerable version of okio